### PR TITLE
Prevent browsers from adding "Submit" to the submit button.

### DIFF
--- a/src/SearchBar.jsx
+++ b/src/SearchBar.jsx
@@ -124,6 +124,7 @@ class SearchBar extends React.Component {
           <input
             className="icon search-bar-submit"
             type="submit"
+            value=""
             onClick={this.onSubmit.bind(this)} />
         </div>
         { this.state.suggestions.length > 0 &&


### PR DESCRIPTION
Sometimes browsers will set "submit" input types default values to "Submit", which
appears behind the icon.
