### PR TITLE
updated the README from onSearch to onSubmit

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ type: `function`
 
 callback that executes on input and populates suggestions
 
-### onSearch
+### onSubmit
 
 type: `function`
 


### PR DESCRIPTION
With the current README naming convention, using the attribute onSearch will generate the following error: Uncaught TypeError: this.props.onSubmit is not a function. When changed from onSearch to onSubmit, the error is no longer generated. SearchBar expects an onSubmit attribute rather than an onSearch.
