### PR TITLE
Support Search Terms that aren't Prefixes

### DIFF
--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -3,30 +3,26 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import SearchBar from '../src/SearchBar';
 
-const matches = {
-  'macbook a': [
-    'macbook air 13 case',
-    'macbook air 11 case',
-    'macbook air charger'
-  ],
-  'macbook p': [
-    'macbook pro 13 case',
-    'macbook pro 15 case',
-    'macbook pro charger'
-  ]
-};
+const suggestions = [
+  "Batman v Superman: Dawn of Justice",
+  "Superman Returns",
+  "Superman",
+  "Superman II",
+  "Superman III",
+  "Superman IV: The Quest for Peace",
+  "Superman/Batman: Apocalypse",
+  "Lois & Clark: The New Adventures of Superman",
+  "Superman/Batman: Public Enemies",
+  "Superman/Doomsday",
+];
 
 const App = React.createClass({
   onChange(input, resolve) {
     // Simulate AJAX request
     setTimeout(() => {
-      const suggestions = matches[Object.keys(matches).find((partial) => {
-        return input.match(new RegExp(partial), 'i');
-      })] || ['macbook', 'macbook air', 'macbook pro'];
-
-      resolve(suggestions.filter((suggestion) =>
-        suggestion.match(new RegExp('^' + input.replace(/\W\s/g, ''), 'i'))
-      ));
+      if (input.toLowerCase() === 'superman') {
+        resolve(suggestions);
+      }
     }, 25);
   },
   onSearch(input) {
@@ -36,7 +32,7 @@ const App = React.createClass({
   render() {
     return (
       <SearchBar
-        placeholder="search 'mac'"
+        placeholder="search 'superman'"
         onChange={this.onChange}
         onSearch={this.onSearch} />
     );

--- a/src/SearchBar.jsx
+++ b/src/SearchBar.jsx
@@ -29,7 +29,7 @@ class SearchBar extends React.Component {
     }
   }
   normalizeInput() {
-    return this.state.value.toLowerCase().trim();
+    return this.state.value.trim();
   }
   autosuggest() {
     const searchTerm = this.normalizeInput();

--- a/src/Suggestions.jsx
+++ b/src/Suggestions.jsx
@@ -33,24 +33,37 @@ class Suggestions extends React.Component {
       <ul
         className="search-bar-suggestions"
         onMouseLeave={() => this.setState({activeItem: -1})}>
-        {suggestions.map((suggestion, index) =>
-          <li
-            className={classNames({
-              highlighted: highlightedItem === index || activeItem === index
-            })}
-            key={index}
-            onClick={() => this.props.onSelection(suggestion)}
-            onMouseEnter={() => this.setState({activeItem: index})}
-            onMouseDown={(e) => e.preventDefault()}
-            onTouchStart={() => this.onTouchStart(index)}
-            onTouchMove={() => this.onTouchMove()}
-            onTouchEnd={() => this.onTouchEnd(suggestion)}>
-            <span>
-              {searchTerm}
-              <strong>{suggestion.substr(searchTerm.length)}</strong>
-            </span>
-          </li>
-        )}
+        {suggestions.map((suggestion, index) => {
+          const lowerSearchTerm = searchTerm.toLowerCase()
+          const lowerSuggestion = suggestion.toLowerCase();
+          const searchTermStartIndex = lowerSuggestion.indexOf(lowerSearchTerm);
+          const searchTermEndIndex = searchTermStartIndex + lowerSearchTerm.length;
+          const leftSuggestionFragment = suggestion.substring(0, searchTermStartIndex);
+          const rightSuggestionFragment = suggestion.substring(searchTermEndIndex);
+          return (
+            <li
+              className={classNames({
+                highlighted: highlightedItem === index || activeItem === index
+              })}
+              key={index}
+              onClick={() => this.props.onSelection(suggestion)}
+              onMouseEnter={() => this.setState({activeItem: index})}
+              onMouseDown={(e) => e.preventDefault()}
+              onTouchStart={() => this.onTouchStart(index)}
+              onTouchMove={() => this.onTouchMove()}
+              onTouchEnd={() => this.onTouchEnd(suggestion)}>
+              <span>
+                {leftSuggestionFragment !== '' &&
+                  <span>{leftSuggestionFragment}</span>
+                }
+                <strong>{searchTerm}</strong>
+                {rightSuggestionFragment !== '' &&
+                  <span>{rightSuggestionFragment}</span>
+                }
+              </span>
+            </li>
+          );
+        })}
       </ul>
     );
   }

--- a/src/Suggestions.jsx
+++ b/src/Suggestions.jsx
@@ -54,11 +54,11 @@ class Suggestions extends React.Component {
               onTouchEnd={() => this.onTouchEnd(suggestion)}>
               <span>
                 {leftSuggestionFragment !== '' &&
-                  <span>{leftSuggestionFragment}</span>
+                  <strong>{leftSuggestionFragment}</strong>
                 }
-                <strong>{searchTerm}</strong>
+                <span>{searchTerm}</span>
                 {rightSuggestionFragment !== '' &&
-                  <span>{rightSuggestionFragment}</span>
+                  <strong>{rightSuggestionFragment}</strong>
                 }
               </span>
             </li>


### PR DESCRIPTION
## Issue

The current implementation will splice the `searchTerm` into each of the suggestions at the beginning of the suggestion regardless of its location in the suggestion as shown here:
![anim](https://cloud.githubusercontent.com/assets/2865469/18900912/029232da-84fb-11e6-9d7c-f1d240a543cf.gif)
## Resolution

This PR accounts for `searchTerm`s in any part of a suggestion as shown here:
![anim](https://cloud.githubusercontent.com/assets/2865469/18900991/ccc13e84-84fb-11e6-922d-4eae2f37ed13.gif)
## Demo

This PR also includes an update to the demo to illustrate the added functionality
## Feedback

`react-search-bar` is really cool! I came across the above issue and was able to solve it so hoping I can contribute that back. Let me know if there's anything further I can do to get this change into `react-search-bar` or why you feel it shouldn't be part if not. Thanks!
## Credit

Worked on this with @ycanastra
